### PR TITLE
Added extra random sequence to JSONP in order to avoid duplicate functions names

### DIFF
--- a/m.html
+++ b/m.html
@@ -318,7 +318,7 @@ m.ajax = function (conf, xhr) {
 m.jsonp = function (conf, head, scripttag) {
 	head = doc.getElementsByTagName('head')[0],
 	scripttag = doc.createElement(script),
-	conf.callback && (window[conf._ = conf._ || script + (+new Date())] = function(){
+	conf.callback && (window[conf._ = conf._ || script + (+new Date()+Math.floor((Math.random() * 10000) + 1))] = function(){
 		head.removeChild(scripttag);
 		conf.callback.apply(this, arguments);
 		window[conf._] = undef


### PR DESCRIPTION
![duplicate_callbacks](https://cloud.githubusercontent.com/assets/835173/13003018/440cc3ba-d173-11e5-88ac-cd4647514887.png)
Sometimes if several JSONP requests are performed in the same milisecond the same callback function is retrieved and imported into the window scope. Those duplicate callback functions becomes invalidated when they called because they are re-loaded. In order to avoid this issue I added a little bit of entropy adding a random number between 1 and 10000 to the timestamp number.

This is not a very elegant solution because there is a little possibility to get the same callback name, but it is a fast method.

I enclose a screenshot of the error raised when duplicate callbacks functions are used.
